### PR TITLE
Add FastLED as ESP-IDF component support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+# FastLED
+# https://github.com/FastLED/FastLED
+# MIT License
+
+cmake_minimum_required(VERSION 3.5)
+
+set(FastLED_SRCS
+  src/bitswap.cpp
+  src/colorpalettes.cpp
+  src/colorutils.cpp
+  src/FastLED.cpp
+  src/hsv2rgb.cpp
+  src/lib8tion.cpp
+  src/noise.cpp
+  src/platforms.cpp
+  src/power_mgt.cpp
+  src/wiring.cpp
+  )
+
+idf_component_register(SRCS ${FastLED_SRCS}
+                       INCLUDE_DIRS "src"
+                       REQUIRES arduino)
+
+project(FastLED)


### PR DESCRIPTION
Enables FastLED as ESP-IDF component support (with Arduino as component)